### PR TITLE
Support for resetting the element to empty state

### DIFF
--- a/jquery.minimalect.js
+++ b/jquery.minimalect.js
@@ -86,21 +86,19 @@
 					markup = m.parseSelect(m.element, m.options);
 
 				if(m.element.val() != current.attr("data-value")){
-					var callback = function(){
-						m.wrapper.children("ul").html(markup+'<li class="'+m.options.class_empty+'">'+m.options.empty+'</li>');
-						m.selectChoice(m.wrapper.find('li[data-value="'+m.element.val()+'"]'), m.wrapper, m.element, m.options);
-					};
-					if (m.element.val() === "") {
-						callback = function(){
+					m.hideChoices(m.wrapper, m.options, function() {
+						if (m.element.val() === "") {
 							// A common convention is to have an
 							// empty option in a select list to act
 							// as a place holder. Thus we only want
 							// display an input value if the input
 							// is non-empty
 							m.wrapper.children("input").val('').attr('placeholder', m.options.placeholder);
-						};
-					}
-					m.hideChoices(m.wrapper, m.options, callback);
+						} else {
+							m.wrapper.children("ul").html(markup+'<li class="'+m.options.class_empty+'">'+m.options.empty+'</li>');
+							m.selectChoice(m.wrapper.find('li[data-value="'+m.element.val()+'"]'), m.wrapper, m.element, m.options);
+						}
+					});
 				}
 			});
 
@@ -235,10 +233,7 @@
 			// go through each option
 			$( $.trim(elhtml) ).filter("option").each(function(){
 				var $el = $(this);
-				if ($el.attr('value') === '') {
-					return;
-				}
-
+				if ($el.attr('value') === '') return;
 				// create an li with a data attribute containing its value
 				readyhtml += '<li data-value="'+$el.val()+'" class="'+($el.attr("class") || "")+'">'+$el.text()+'</li>';
 			});


### PR DESCRIPTION
Many of my un-enhanced select elements have a "placeholder" option. This is an option with en empty value and text that serves as a place holder.

Though Minimalect does not allow you to choose an empty option, it is sometimes useful to "reset" the plugin's view by manually selecting the empty option. I have added support for resetting the enhanced select widget using the following syntax:

$('select').val('').change();

This is inline with the regular flow of Minimalect.

I have made sure to ignore empty options in the parseElements function. I achieve this effect by supplying a different callback in the change handler depending on whether or not the element's value is empty.
