### PR TITLE
A bunch of usability fixes

### DIFF
--- a/jquery.minimalect.js
+++ b/jquery.minimalect.js
@@ -155,6 +155,11 @@
 				m.filterChoices(m.wrapper, m.options)
 			});
 
+			// When tabbing out of minimalect, close it
+			$('input, select, button, textarea, a').not(m.wrapper.find("input")).on('focus', function(){
+				m.hideChoices(m.wrapper, m.options);
+			});
+
 			// after init callback
 			this.options.afterinit();
 		},


### PR DESCRIPTION
Label: Activates minimalect when a label with for="select-id" attribute is
clicked, as in native form behavior.

Tabindex: Adds the tabindex from the native select element, if present, to the
minimalect input. Improves tabbing through the form.

Prevent enter key from submitting the form.

Close minimalect when tabbing out of it.
