### PR TITLE
Access to element during onChange callback

### DIFF
--- a/jquery.minimalect.js
+++ b/jquery.minimalect.js
@@ -571,7 +571,7 @@
 			this._showResetLink();
 
 			// callback
-			this.options.onchange(ch.data("value"), ch.text());
+			this.options.onchange.call(this, ch.data("value"), ch.text());
 		},
 
 		// clear the select


### PR DESCRIPTION
It would be great to have access to either the select element or the minimalect instance during the onChange callback. Currently the scope of the callback is the settings object which means it isn't possible to know which select the callback is for.

Simple example:

```
$("select").minimalect({
   onchange: function(value, text) {
       this.element // undefined
   }
});
```

I've attached a pull request with the thisRef updated but you could also just pass the element reference through as an additional parameter.
